### PR TITLE
Add nordvpn feed

### DIFF
--- a/net/nordvpn/Makefile
+++ b/net/nordvpn/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nordvpn
+PKG_VERSION:=ee3967fc8f672aecf9ac6c3686964a62b0b70442
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/NordSecurity/libtelio.git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=skip
+
+PKG_MAINTAINER:=Lukas Pukenis <lukas.pukenis@nordsecurity.com>
+PKG_LICENSE:=GPLv3
+PKG_BUILD_PARALLEL:=1
+
+PKG_BUILD_DEPENDS:=rust/host
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+# +kmod-tun is required, however teliod has NepTUN built-in so +kmod-wireguard could, potentially, be optional
+define Package/nordvpn
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=NordVPN
+	DEPENDS:=$(RUST_ARCH_DEPENDS) +kmod-tun +kmod-wireguard
+	URL:=https://www.nordsecurity.com
+endef
+
+define Package/nordvpn/description
+	NordVPN is the gateway to a secure and private access to the internet.
+endef
+
+define Build/Compile
+	$(info RUSTC_TARGET_ARCH=$(RUSTC_TARGET_ARCH))	
+	cd $(PKG_BUILD_DIR) && $(CARGO_PKG_VARS) BYPASS_LLT_SECRETS=1 cargo build -p teliod --release --target $(RUSTC_TARGET_ARCH)
+endef
+
+define Package/nordvpn/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/target/$(RUSTC_TARGET_ARCH)/release/teliod $(1)/usr/sbin/nordvpn
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nordvpn.init $(1)/etc/init.d/nordvpn
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/nordvpn.conf $(1)/etc/config/nordvpn
+	$(INSTALL_DIR) $(1)/etc/nordvpn
+	$(INSTALL_DATA) ./files/config.json $(1)/etc/nordvpn/config.json
+endef
+
+$(eval $(call RustBinPackage,nordvpn))
+$(eval $(call BuildPackage,nordvpn))

--- a/net/nordvpn/files/config.json
+++ b/net/nordvpn/files/config.json
@@ -1,0 +1,17 @@
+{
+  "log_level": "error",
+  "log_file_path": "/var/log/nordvpn.log",
+  "log_file_count": 0,
+  "authentication_token": "AUTHENTICATION_TOKEN",
+  "adapter_type": "linux-native",
+  "device_identity_file_path": "/etc/nordvpn/data.json",
+  "interface": {
+    "name": "nordvpn",
+    "config_provider": "uci"
+  },
+  "vpn": {
+    "server_endpoint": "IP:PORT",
+    "server_pubkey": "PUBLIC_KEY"
+  }
+}
+

--- a/net/nordvpn/files/nordvpn.conf
+++ b/net/nordvpn/files/nordvpn.conf
@@ -1,0 +1,1 @@
+config settings 'settings'

--- a/net/nordvpn/files/nordvpn.init
+++ b/net/nordvpn/files/nordvpn.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=10
+
+start_service() {
+  procd_open_instance
+  procd_set_param command /usr/sbin/nordvpn start /etc/nordvpn/config.json
+  procd_set_param respawn
+  procd_close_instance
+}
+
+stop_service() {
+  /usr/sbin/nordvpn quit-daemon
+}
+


### PR DESCRIPTION
Add OpenWRT feed for Nordvpn app(teliod really).

Feed is just a URI with certain structure and a Makefile or specific format. OpenWRT runtime ingests the feed and is then aware of the package and steps to do for it(check, clean, compile, install, uninstall). Makefile defines how it is compiled.

Once the feed is merged to the official OpenWRT repo, then the clients will simply have access to the package without the need to modify and add a custom feed(like this repository). Additionally, OpenWRT will take care of running compilation for us for all the supported target platforms.